### PR TITLE
Fix instance may not be null

### DIFF
--- a/NotificationCounter@coolllsk/extension.js
+++ b/NotificationCounter@coolllsk/extension.js
@@ -30,6 +30,8 @@ class MessageCounterIndicator extends St.Label {
 
         let sources = Main.messageTray.getSources();
         sources.forEach(Lang.bind(this, function(source) { this._onSourceAdded(null, source); }));
+
+        this.connect('destroy', (actor) => actor._signals.forEach( (sig) => sig[0].disconnect(sig[1]) ));
     }
 
     _onSourceAdded(tray, source) {
@@ -71,11 +73,6 @@ class MessageCounterIndicator extends St.Label {
     _connectSignal(target, signal, callback) {
         let s = target.connect(signal, callback);
         this._signals.push([target, s])
-    }
-
-    destroy() {
-        this._signals.forEach( (sig) => sig[0].disconnect(sig[1]) );
-        super.destroy();
     }
 });
 


### PR DESCRIPTION
Reworked disconnection of source signals to fix errors when a signal was destroyed prior to the disconnection:
```
Argument 'instance' (type interface) may not be null
```

Resolves #3 and #4 (hopefully).
