### PR TITLE
Add Support to Gnome 47

### DIFF
--- a/NotificationCounter@coolllsk/metadata.json
+++ b/NotificationCounter@coolllsk/metadata.json
@@ -1,6 +1,9 @@
 {
   "name": "Notification Counter",
-  "shell-version": ["46"],
+  "shell-version": [
+    "46",
+    "47"
+  ],
   "description": "Shows number of notifications in queue.",
   "uuid": "NotificationCounter@coolllsk",
   "url": "https://github.com/vkrizan/NotificationCounter",


### PR DESCRIPTION
I tested it on gnome 47 and it seems to be working fine.

Please release a new version.