### PR TITLE
Add GNOME 49 support

### DIFF
--- a/NotificationCounter@coolllsk/metadata.json
+++ b/NotificationCounter@coolllsk/metadata.json
@@ -3,7 +3,8 @@
   "shell-version": [
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "description": "Shows number of notifications in queue.",
   "uuid": "NotificationCounter@coolllsk",


### PR DESCRIPTION
No relevant changes in the shell. Just added `49` to the list of supported versions.